### PR TITLE
swagger api document에 error code 추가

### DIFF
--- a/src/main/java/prezwiz/server/SwaggerConfig.java
+++ b/src/main/java/prezwiz/server/SwaggerConfig.java
@@ -2,14 +2,28 @@ package prezwiz.server;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import prezwiz.server.common.annotation.ApiErrorCodeExample;
+import prezwiz.server.common.exception.BizBaseException;
+import prezwiz.server.common.exception.ErrorCode;
+import prezwiz.server.common.exception.ErrorResponse;
+
+import java.util.Arrays;
 
 @Configuration
 public class SwaggerConfig {
@@ -32,5 +46,40 @@ public class SwaggerConfig {
         return new SecurityScheme().type(SecurityScheme.Type.HTTP)
                 .bearerFormat("JWT")
                 .scheme("bearer");
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (operation, handlerMethod) -> {
+            ApiErrorCodeExample apiErrorCodeExample = handlerMethod.getMethodAnnotation(ApiErrorCodeExample.class);
+
+            ApiResponses responses = operation.getResponses();
+            if (apiErrorCodeExample != null) {
+                addErrorCodeExamplesToResponses(responses, apiErrorCodeExample.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void addErrorCodeExamplesToResponses(ApiResponses responses, ErrorCode[] errorCodes) {
+        ApiResponse apiResponse = new ApiResponse();
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+
+        for (ErrorCode errorCode : errorCodes)
+            mediaType.addExamples(errorCode.getCode(), makeExample(errorCode));
+
+        content.addMediaType("application/json", mediaType);
+        apiResponse.setContent(content);
+        responses.addApiResponse("error", apiResponse);
+    }
+
+    private Example makeExample(ErrorCode errorCode) {
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getMsg(), errorCode.getCode());
+        Example example = new Example();
+        example.description(errorCode.getMsg());
+        example.setValue(errorResponse);
+        return example;
     }
 }

--- a/src/main/java/prezwiz/server/common/annotation/ApiErrorCodeExample.java
+++ b/src/main/java/prezwiz/server/common/annotation/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package prezwiz.server.common.annotation;
+
+import prezwiz.server.common.exception.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+    ErrorCode[] value();
+}

--- a/src/main/java/prezwiz/server/common/exception/ErrorCode.java
+++ b/src/main/java/prezwiz/server/common/exception/ErrorCode.java
@@ -12,10 +12,8 @@ public enum ErrorCode {
   INVALID_VALUE(HttpStatus.BAD_REQUEST, "4000", "잘못된 요청입니다."),
   AUTH_INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "4001", "지정한 리소스에 대한 엑세스 권한이 없습니다."),
   NOT_FOUND(HttpStatus.NOT_FOUND, "4004", "존재하지 않는 경로입니다."),
-
   MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "4005", "존재하지 않는 유저입니다."),
   PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "4006", "비밀번호가 일치하지 않습니다."),
-
   PRESENTATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "4008", "존재하지 않는 presentation입니다."),
 
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "internal server error");

--- a/src/main/java/prezwiz/server/common/exception/ErrorCode.java
+++ b/src/main/java/prezwiz/server/common/exception/ErrorCode.java
@@ -7,16 +7,26 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
+  // 1000~1999 : 공통적으로 일어나는 에러
+  INVALID_VALUE(HttpStatus.BAD_REQUEST, "1001", "잘못된 요청입니다."),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "1002", "존재하지 않는 경로입니다."),
+
+  // 2000~2999 : 회원가입, 로그인 관련
   CONFLICT_EXIST_EMAIL(HttpStatus.CONFLICT, "2001", "이미 사용중인 이메일입니다"),
+  MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "2002", "존재하지 않는 유저입니다."),
+  PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "2003", "비밀번호가 일치하지 않습니다."),
+  INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "2004", "이메일 형식이 올바르지 않습니다."),
+  INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "2005", "비밀번호는 최소 8자리 이상, 영어 대문자,소문자,숫자,특수문자를 포함해주세요"),
+  EMPTY_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "2006", "이메일 또는 비밀번호가 비어 있습니다."),
 
-  INVALID_VALUE(HttpStatus.BAD_REQUEST, "4000", "잘못된 요청입니다."),
-  AUTH_INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "4001", "지정한 리소스에 대한 엑세스 권한이 없습니다."),
-  NOT_FOUND(HttpStatus.NOT_FOUND, "4004", "존재하지 않는 경로입니다."),
-  MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "4005", "존재하지 않는 유저입니다."),
-  PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "4006", "비밀번호가 일치하지 않습니다."),
-  PRESENTATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "4008", "존재하지 않는 presentation입니다."),
+  // 3000~3999 : presentation 관련
+  AUTH_INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "3001", "지정한 리소스에 대한 엑세스 권한이 없습니다."),
+  PRESENTATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "3002", "존재하지 않는 presentation입니다."),
 
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "internal server error");
+  // 5000~5999 : 서버에서 일어나는 오류 ( httpStatus 5xx )
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "internal server error"),
+  GPT_API_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "gpt api와 통신중 오류가 발생했습니다. 5xx"),
+  GPT_API_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5002", "gpt api와 통신중 오류가 발생했습니다. 4xx");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
+++ b/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
@@ -6,8 +6,11 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import prezwiz.server.common.exception.BizBaseException;
+import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.dto.slide.SlidesDto;
 import prezwiz.server.dto.slide.gptapi.request.GPTRequest;
 import prezwiz.server.dto.slide.gptapi.request.Message;
@@ -122,6 +125,8 @@ public class GptUtilImpl implements GptUtil{
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON.toString())
                 .body(Mono.just(request), GPTRequest.class)
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.GPT_API_CLIENT_ERROR)))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.GPT_API_INTERNAL_ERROR)))
                 .bodyToMono(GPTResponse.class)
                 .block();
     }

--- a/src/main/java/prezwiz/server/controller/MemberController.java
+++ b/src/main/java/prezwiz/server/controller/MemberController.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
+import prezwiz.server.common.annotation.ApiErrorCodeExample;
+import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.dto.request.auth.AuthDto;
 import prezwiz.server.dto.request.auth.JoinRequestDto;
 import prezwiz.server.dto.request.auth.LoginRequestDto;
@@ -34,6 +36,11 @@ public class MemberController {
      */
     @PostMapping("/member")
     @Operation(summary = "회원가입")
+    @ApiErrorCodeExample({
+            ErrorCode.CONFLICT_EXIST_EMAIL,
+            ErrorCode.EMPTY_EMAIL_OR_PASSWORD,
+            ErrorCode.INVALID_EMAIL_FORMAT,
+            ErrorCode.INVALID_PASSWORD_FORMAT})
     public ResponseEntity<ResponseDto> join(@RequestBody JoinRequestDto request) {
         return memberService.saveMember(request);
     }
@@ -43,6 +50,7 @@ public class MemberController {
      */
     @PostMapping("/login")
     @Operation(summary = "로그인")
+    @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND, ErrorCode.PASSWORD_NOT_MATCH})
     public ResponseEntity<ResponseDto> login(@RequestBody LoginRequestDto request) {
         return authService.login(request);
     }
@@ -52,6 +60,7 @@ public class MemberController {
      */
     @DeleteMapping("/member")
     @Operation(summary = "회원탈퇴")
+    @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND})
     public ResponseDto withdraw(@AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();
         return authService.withdraw(email);
@@ -62,6 +71,7 @@ public class MemberController {
      */
     @PatchMapping("/member/password")
     @Operation(summary = "비밀번호 수정")
+    @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND, ErrorCode.PASSWORD_NOT_MATCH})
     public ResponseDto modifyPassword(@AuthenticationPrincipal UserDetails userDetails,
                                       @RequestBody AuthDto.ModifyPasswordReq dto) {
         String email = userDetails.getUsername();
@@ -74,6 +84,7 @@ public class MemberController {
      */
     @GetMapping("/kakaoauth")
     @Operation(summary = "카카오 로그인")
+    @ApiErrorCodeExample({ErrorCode.INVALID_VALUE})
     public RedirectView kakaoLogin(@RequestParam String code, HttpServletResponse response) {
         return kaKaoAuthService.kakaoAuth(code, response);
     }

--- a/src/main/java/prezwiz/server/controller/SlideController.java
+++ b/src/main/java/prezwiz/server/controller/SlideController.java
@@ -37,10 +37,6 @@ public class SlideController {
 
     @PostMapping("/prez/slides/{presentationId}")
     @Operation(summary = "슬라이드 생성")
-    @ApiErrorCodeExample({
-            ErrorCode.MEMBER_NOT_FOUND,
-            ErrorCode.PRESENTATION_NOT_FOUND,
-            ErrorCode.INVALID_VALUE})
     public ResponseEntity<SlidesDto> createSlides(@RequestBody PrototypesDto prototypesDto, @PathVariable("presentationId") Long id) {
         SlidesDto slidesDto = prezService.makeSlide(prototypesDto, id);
         return ResponseEntity.ok(slidesDto);

--- a/src/main/java/prezwiz/server/controller/SlideController.java
+++ b/src/main/java/prezwiz/server/controller/SlideController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import prezwiz.server.common.adapter.PrezServiceAdapter;
+import prezwiz.server.common.annotation.ApiErrorCodeExample;
+import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.dto.response.ScriptResponseDto;
 import prezwiz.server.dto.request.CreateOutlineRequestDto;
 import prezwiz.server.dto.response.PrototypeResponseDto;
@@ -20,7 +22,6 @@ import prezwiz.server.service.prez.PrezService;
 public class SlideController {
 
     private final PrezService prezService;
-    private final PrezServiceAdapter prezServiceAdapter;
 
     @PostMapping("/prez/prototype")
     @Operation(summary = "프로토타입 생성",
@@ -36,6 +37,10 @@ public class SlideController {
 
     @PostMapping("/prez/slides/{presentationId}")
     @Operation(summary = "슬라이드 생성")
+    @ApiErrorCodeExample({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.PRESENTATION_NOT_FOUND,
+            ErrorCode.INVALID_VALUE})
     public ResponseEntity<SlidesDto> createSlides(@RequestBody PrototypesDto prototypesDto, @PathVariable("presentationId") Long id) {
         SlidesDto slidesDto = prezService.makeSlide(prototypesDto, id);
         return ResponseEntity.ok(slidesDto);

--- a/src/main/java/prezwiz/server/controller/SlideControllerV2.java
+++ b/src/main/java/prezwiz/server/controller/SlideControllerV2.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import prezwiz.server.common.adapter.PrezServiceAdapter;
+import prezwiz.server.common.annotation.ApiErrorCodeExample;
+import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.dto.request.CreateOutlineRequestDto;
 import prezwiz.server.dto.response.OutlineResponseDto;
 import prezwiz.server.dto.response.PresentationsResponseDto;
@@ -26,20 +28,28 @@ public class SlideControllerV2 {
             description =
                     "response json 에는 이후 요청을 위한 presentationId를 같이 반환합니다." +
                             "\n 이후에 slide를 생성하거나, script를 생성할때 url경로에 같이 보내줘야 합니다.")
-    public ResponseEntity<OutlineResponseDto> createOutlineV2(@RequestBody CreateOutlineRequestDto request) {
+    @ApiErrorCodeExample({ErrorCode.PRESENTATION_NOT_FOUND, ErrorCode.MEMBER_NOT_FOUND})
+    public ResponseEntity<OutlineResponseDto> createOutline(@RequestBody CreateOutlineRequestDto request) {
         OutlineResponseDto outline = prezServiceAdapter.outline(request.getTopic());
         return ResponseEntity.ok(outline);
     }
 
     @PostMapping("/slides/{presentationId}")
     @Operation(summary = "슬라이드 생성")
-    public ResponseEntity<SlidesDto> createSlidesDataV2(@RequestBody OutlinesDto outlinesDto, @PathVariable("presentationId") Long id) {
+    @ApiErrorCodeExample({
+            ErrorCode.PRESENTATION_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.GPT_API_CLIENT_ERROR,
+            ErrorCode.GPT_API_INTERNAL_ERROR,
+            ErrorCode.AUTH_INVALID_ACCESS_TOKEN})
+    public ResponseEntity<SlidesDto> createSlidesData(@RequestBody OutlinesDto outlinesDto, @PathVariable("presentationId") Long id) {
         SlidesDto slidesDto = prezServiceAdapter.slide(outlinesDto, id);
         return ResponseEntity.ok(slidesDto);
     }
 
     @GetMapping("/slides/{presentationId}")
     @Operation(summary = "슬라이드 가져오기")
+    @ApiErrorCodeExample({ErrorCode.PRESENTATION_NOT_FOUND, ErrorCode.MEMBER_NOT_FOUND, ErrorCode.AUTH_INVALID_ACCESS_TOKEN})
     public ResponseEntity<SlidesDto> getSlidesData(@PathVariable("presentationId") Long id) {
         SlidesDto slides = prezServiceAdapter.getSlide(id);
         return ResponseEntity.ok(slides);
@@ -47,12 +57,19 @@ public class SlideControllerV2 {
 
     @PutMapping("/slides/{presentationId}")
     @Operation(summary = "슬라이드 수정")
+    @ApiErrorCodeExample({ErrorCode.PRESENTATION_NOT_FOUND, ErrorCode.MEMBER_NOT_FOUND, ErrorCode.AUTH_INVALID_ACCESS_TOKEN})
     public void updateSlideDataV2(@RequestBody SlidesDto slidesDto, @PathVariable("presentationId") Long id) {
         prezServiceAdapter.updateSlide(id, slidesDto);
     }
 
     @PostMapping("/script/{presentationId}")
     @Operation(summary = "대본 가져오기")
+    @ApiErrorCodeExample({
+            ErrorCode.PRESENTATION_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.GPT_API_CLIENT_ERROR,
+            ErrorCode.GPT_API_INTERNAL_ERROR,
+            ErrorCode.AUTH_INVALID_ACCESS_TOKEN})
     public ResponseEntity<ScriptResponseDto> createAndGetScript(@RequestBody SlidesDto slidesDto, @PathVariable("presentationId") Long id) {
         ScriptResponseDto scriptResponse = prezServiceAdapter.getScript(slidesDto, id);
         return ResponseEntity.ok(scriptResponse);
@@ -60,6 +77,7 @@ public class SlideControllerV2 {
 
     @GetMapping("/store")
     @Operation(summary = "모든 슬라이드 정보 가져오기")
+    @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND})
     public ResponseEntity<PresentationsResponseDto> getPresentation() {
         PresentationsResponseDto presentations = prezServiceAdapter.getSlides();
         return ResponseEntity.ok(presentations);

--- a/src/main/java/prezwiz/server/service/auth/AuthServiceImpl.java
+++ b/src/main/java/prezwiz/server/service/auth/AuthServiceImpl.java
@@ -85,7 +85,7 @@ public class AuthServiceImpl implements AuthService {
 
 
         if (!passwordEncoder.matches(dto.getCurrentPassword(), member.getPassword())){
-            throw new IllegalArgumentException("password not matched");
+            throw new BizBaseException(ErrorCode.PASSWORD_NOT_MATCH);
         }
 
         member.modifyPassword(passwordEncoder.encode(dto.getNewPassword()));

--- a/src/main/java/prezwiz/server/service/auth/KaKaoAuthService.java
+++ b/src/main/java/prezwiz/server/service/auth/KaKaoAuthService.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.view.RedirectView;
+import prezwiz.server.common.exception.BizBaseException;
+import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.dto.CustomUserInfoDto;
 import prezwiz.server.dto.kakao.KaKaoTokenDto;
 import prezwiz.server.dto.kakao.KaKaoUserInfoDto;
@@ -69,8 +71,8 @@ public class KaKaoAuthService {
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
                 // Exception
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.INVALID_VALUE)))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.INTERNAL_SERVER_ERROR)))
                 .bodyToMono(KaKaoTokenDto.class)
                 .block();
 
@@ -95,8 +97,8 @@ public class KaKaoAuthService {
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
                 // Exception
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.INVALID_VALUE)))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BizBaseException(ErrorCode.INTERNAL_SERVER_ERROR)))
                 .bodyToMono(KaKaoUserInfoDto.class)
                 .block();
         return userInfo.getKaKaoAccount().getEmail();

--- a/src/main/java/prezwiz/server/service/auth/MemberService.java
+++ b/src/main/java/prezwiz/server/service/auth/MemberService.java
@@ -40,10 +40,10 @@ public class MemberService {
 
         if (isNull(email, password)) {
             log.error("잘못된 요청");
-            throw new BizBaseException(ErrorCode.INVALID_VALUE);
+            throw new BizBaseException(ErrorCode.EMPTY_EMAIL_OR_PASSWORD);
         } else if (isEmailDuplicate(email)) {
             log.error("중복 이메일");
-            throw new BizBaseException(ErrorCode.INVALID_VALUE);
+            throw new BizBaseException(ErrorCode.CONFLICT_EXIST_EMAIL);
         } else {
             String memberRole = role == null ? "user" : role;
             Member member = new Member(email, encoder.encode(password), memberRole);

--- a/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
+++ b/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
@@ -60,8 +60,8 @@ public class PrezServiceImpl implements PrezService {
     @Override
     @Transactional
     public SlidesDto makeSlide(PrototypesDto prototypesDto, Long presentationId) {
-        SlidesDto slidesDto = gptUtil.getSlides(prototypesDto);
         Presentation presentation = getMyPresentation(presentationId);
+        SlidesDto slidesDto = gptUtil.getSlides(prototypesDto);
 
         // 영속성 전이를 사용하지 않고 저장했음
         Slides slides = new Slides();
@@ -174,6 +174,10 @@ public class PrezServiceImpl implements PrezService {
     private Member getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContextHolderStrategy().getContext().getAuthentication();
         String currentUserEmail = authentication.getName();
-        return memberRepository.findMemberByEmail(currentUserEmail);
+        Member member = memberRepository.findMemberByEmail(currentUserEmail);
+        if (member == null) {
+            throw new BizBaseException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        return member;
     }
 }


### PR DESCRIPTION
swagger api 에 발생가능한 error와 그 error의 code를 보여주기 위한, ApiErrorCodeExample 어노테이션을 추가하고, 적용하였습니다.
그 과정에서 service의 로직이 조금 수정되었습니다.