### PR TITLE
prototype 의존성 제거(v2애서 사용하지 않음) , 영속성 전이를 사용해 entity를 저장및 수정, deletePrez api 추가

### DIFF
--- a/src/main/java/prezwiz/server/common/adapter/PrezServiceAdapter.java
+++ b/src/main/java/prezwiz/server/common/adapter/PrezServiceAdapter.java
@@ -25,33 +25,14 @@ public class PrezServiceAdapter {
 
         // table 생성
         Long presentationId = prezService.makeTable();
-        PrototypesDto prototypesDto = prezService.makeOutline(topic, presentationId);
+        // outline 생성
+        OutlinesDto outlinesDto = prezService.makeOutline(topic, presentationId);
 
-        OutlineResponseDto outlineResponseDto = new OutlineResponseDto();
-        List<OutlineDto> outlines = new ArrayList<>();
-
-        prototypesDto.getSlides().forEach(
-                prototypeDto -> {
-                    outlines.add(new OutlineDto(prototypeDto.getSlideNumber(), prototypeDto.getTitle(), prototypeDto.getTitle()));
-                }
-        );
-
-        outlineResponseDto.setPresentationId(presentationId);
-        outlineResponseDto.setOutlines(outlines);
-        return outlineResponseDto;
+        return new OutlineResponseDto(presentationId, outlinesDto.getOutlines());
     }
 
     public SlidesDto slide(OutlinesDto outlinesDto, Long presentationId) {
-
-        PrototypesDto prototypesDto = new PrototypesDto();
-        List<PrototypeDto> prototypes = new ArrayList<>();
-
-        List<OutlineDto> outlines = outlinesDto.getOutlines();
-        outlines.forEach(outline -> {
-            prototypes.add(new PrototypeDto(outline.getOutlineNumber(), outline.getTitle(), outline.getDescription()));
-        });
-        prototypesDto.setSlides(prototypes);
-        return prezService.makeSlide(prototypesDto, presentationId);
+        return prezService.makeSlide(outlinesDto, presentationId);
     }
 
     public void updateSlide(Long id, SlidesDto slides) {

--- a/src/main/java/prezwiz/server/common/adapter/PrezServiceAdapter.java
+++ b/src/main/java/prezwiz/server/common/adapter/PrezServiceAdapter.java
@@ -52,4 +52,8 @@ public class PrezServiceAdapter {
     public PresentationsResponseDto getSlides() {
         return prezService.getPresentations();
     }
+
+    public void deletePrez(Long presentationId) {
+        prezService.deletePrez(presentationId);
+    }
 }

--- a/src/main/java/prezwiz/server/common/exception/ErrorCode.java
+++ b/src/main/java/prezwiz/server/common/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
   // 5000~5999 : 서버에서 일어나는 오류 ( httpStatus 5xx )
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "internal server error"),
   GPT_API_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "gpt api와 통신중 오류가 발생했습니다. 5xx"),
-  GPT_API_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5002", "gpt api와 통신중 오류가 발생했습니다. 4xx");
+  GPT_API_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5002", "gpt api와 통신중 오류가 발생했습니다. 4xx"),
+  JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5003", "json 응답을 파싱하는중 오류가 발생했습니다."),
+  OBJECT_MAPPING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5004", "객체를 json 으로 만드는 중 오류가 발생했습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/prezwiz/server/common/util/GptUtil.java
+++ b/src/main/java/prezwiz/server/common/util/GptUtil.java
@@ -1,6 +1,7 @@
 package prezwiz.server.common.util;
 
 import prezwiz.server.dto.slide.SlidesDto;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
 import prezwiz.server.dto.slide.prototype.PrototypesDto;
 
 /**
@@ -8,9 +9,9 @@ import prezwiz.server.dto.slide.prototype.PrototypesDto;
  */
 public interface GptUtil {
 
-    PrototypesDto getPrototypes(String topic);
+    OutlinesDto getOutlines(String topic);
 
-    SlidesDto getSlides(PrototypesDto prototypes);
+    SlidesDto getSlides(OutlinesDto outlinesDto);
 
     String getScript(SlidesDto slides);
 }

--- a/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
+++ b/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
@@ -15,6 +15,7 @@ import prezwiz.server.dto.slide.SlidesDto;
 import prezwiz.server.dto.slide.gptapi.request.GPTRequest;
 import prezwiz.server.dto.slide.gptapi.request.Message;
 import prezwiz.server.dto.slide.gptapi.response.GPTResponse;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
 import prezwiz.server.dto.slide.prototype.PrototypeDto;
 import prezwiz.server.dto.slide.prototype.PrototypesDto;
 import reactor.core.publisher.Mono;
@@ -33,15 +34,15 @@ public class GptUtilImpl implements GptUtil{
     private String URI = "/v1/chat/completions";
 
     @Override
-    public PrototypesDto getPrototypes(String topic) {
+    public OutlinesDto getOutlines(String topic) {
         GPTRequest requestBody = makePrototypeRequestBody(topic);
         GPTResponse responseJson = getGptResponse(requestBody);
-        return jsonToObject(responseJson, PrototypesDto.class);
+        return jsonToObject(responseJson, OutlinesDto.class);
     }
 
     @Override
-    public SlidesDto getSlides(PrototypesDto prototypes) {
-        GPTRequest slidesRequest = makeSlidesRequestDto(prototypes);
+    public SlidesDto getSlides(OutlinesDto outlinesDto) {
+        GPTRequest slidesRequest = makeSlidesRequestDto(outlinesDto);
         GPTResponse slidesJson = getGptResponse(slidesRequest);
         return jsonToObject(slidesJson, SlidesDto.class);
     }
@@ -61,27 +62,28 @@ public class GptUtilImpl implements GptUtil{
                 "system",
                 "JSON 형식은 반드시 아래 형식을 따르세요:\n" +
                         "{\n" +
-                        "  \"slides\": [\n" +
-                        "    {\"slide_number\": 1, \"title\": \"PPT 제목\", \"description\": \"프레젠테이션의 전체적인 주제 설명\"},\n" +
-                        "    {\"slide_number\": 2, \"title\": \"목차\", \"description\": \"\"},\n" +
-                        "    {\"slide_number\": 3, \"title\": \"슬라이드 제목\", \"description\": \"슬라이드에 대한 간단한 설명\"}\n" +
+                        "  \"outlines\": [\n" +
+                        "    {\"outline_number\": 0, \"title\": \"PPT 제목\", \"description\": \"프레젠테이션의 전체적인 주제 설명\"},\n" +
+                        "    {\"outline_number\": 1, \"title\": \"목차\", \"description\": \"\"},\n" +
+                        "    {\"outline_number\": 2, \"title\": \"슬라이드 제목\", \"description\": \"슬라이드에 대한 간단한 설명\"}\n" +
                         "  ]\n" +
                         "}\n" +
-                        "첫 번째 슬라이드는 PPT 제목을 포함하고, 두 번째 슬라이드는 목차로 구성하되, " +
-                        "목차 슬라이드의 description은 비워 두세요. 이후의 슬라이드 구성은 주제를 기반으로 만들어주세요."
+                        "첫 번째 아웃라인은 PPT 제목을 포함하고, 두 번째 아웃라인은 목차로 구성하되, " +
+                        "목차 아웃라인의 description은 비워 두세요. 이후의 아웃라인 구성은 주제를 기반으로 만들어주세요."
         );
 
         Message userMessage = new Message(
                 "user",
-                topic + "에 대한 PPT를 만들건데, 각 슬라이드 구성을 만들어줘"
+                topic + "에 대한 PPT의 아웃라인 구성을 만들어줘"
         );
         return new GPTRequest("gpt-4o-mini", Arrays.asList(systemMessage, userMessage));
     }
 
+
     /**
      * 프로토타입을 가지고 슬라이드구성을 만들어 달라고 요청하기위한 객체를 생성
      */
-    private GPTRequest makeSlidesRequestDto(PrototypesDto prototypes) {
+    private GPTRequest makeSlidesRequestDto(OutlinesDto outlinesDto) {
         Message systemMessage = new Message(
                 "system",
                 "JSON 형식은 반드시 다음을 따르세요: {\n" +
@@ -95,7 +97,7 @@ public class GptUtilImpl implements GptUtil{
         );
         Message userMessage = new Message(
                 "user",
-                objectToJson(prototypes) + "\n다음을 바탕으로 발표자료를 만들어줘."
+                objectToJson(outlinesDto) + "\n다음을 바탕으로 발표자료를 만들어줘."
         );
         return new GPTRequest("gpt-4o-mini", Arrays.asList(systemMessage, userMessage));
     }
@@ -139,7 +141,7 @@ public class GptUtilImpl implements GptUtil{
         try {
             return objectMapper.readValue(json, valueType);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("parse problem", e);
+            throw new BizBaseException(ErrorCode.JSON_PARSE_ERROR);
         }
     }
 
@@ -150,7 +152,7 @@ public class GptUtilImpl implements GptUtil{
         try {
             return objectMapper.writeValueAsString(object);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new BizBaseException(ErrorCode.OBJECT_MAPPING_ERROR);
         }
     }
 }

--- a/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
+++ b/src/main/java/prezwiz/server/common/util/GptUtilImpl.java
@@ -63,9 +63,9 @@ public class GptUtilImpl implements GptUtil{
                 "JSON 형식은 반드시 아래 형식을 따르세요:\n" +
                         "{\n" +
                         "  \"outlines\": [\n" +
-                        "    {\"outline_number\": 0, \"title\": \"PPT 제목\", \"description\": \"프레젠테이션의 전체적인 주제 설명\"},\n" +
-                        "    {\"outline_number\": 1, \"title\": \"목차\", \"description\": \"\"},\n" +
-                        "    {\"outline_number\": 2, \"title\": \"슬라이드 제목\", \"description\": \"슬라이드에 대한 간단한 설명\"}\n" +
+                        "    {\"outline_number\": 1, \"title\": \"PPT 제목\", \"description\": \"프레젠테이션의 전체적인 주제 설명\"},\n" +
+                        "    {\"outline_number\": 2, \"title\": \"목차\", \"description\": \"\"},\n" +
+                        "    {\"outline_number\": 3, \"title\": \"슬라이드 제목\", \"description\": \"슬라이드에 대한 간단한 설명\"}\n" +
                         "  ]\n" +
                         "}\n" +
                         "첫 번째 아웃라인은 PPT 제목을 포함하고, 두 번째 아웃라인은 목차로 구성하되, " +

--- a/src/main/java/prezwiz/server/controller/SlideController.java
+++ b/src/main/java/prezwiz/server/controller/SlideController.java
@@ -12,8 +12,14 @@ import prezwiz.server.dto.response.ScriptResponseDto;
 import prezwiz.server.dto.request.CreateOutlineRequestDto;
 import prezwiz.server.dto.response.PrototypeResponseDto;
 import prezwiz.server.dto.slide.SlidesDto;
+import prezwiz.server.dto.slide.outline.OutlineDto;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
+import prezwiz.server.dto.slide.prototype.PrototypeDto;
 import prezwiz.server.dto.slide.prototype.PrototypesDto;
 import prezwiz.server.service.prez.PrezService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Tag(name="slide", description="슬라이드 관련 controller")
 @RestController
@@ -30,7 +36,15 @@ public class SlideController {
                     "\n 이후에 slide를 생성하거나, script를 생성할때 url경로에 같이 보내줘야 합니다.")
     public ResponseEntity<PrototypeResponseDto> createPrototype(@RequestBody CreateOutlineRequestDto request) {
         Long id = prezService.makeTable();
-        PrototypesDto prototypesDto = prezService.makeOutline(request.getTopic(), id);
+        OutlinesDto outlinesDto = prezService.makeOutline(request.getTopic(), id);
+        PrototypesDto prototypesDto = new PrototypesDto();
+        List<PrototypeDto> prototypes = new ArrayList<>();
+
+        for (OutlineDto outline : outlinesDto.getOutlines()) {
+            prototypes.add(new PrototypeDto(outline.getOutlineNumber(), outline.getTitle(), outline.getDescription()));
+        }
+        prototypesDto.setSlides(prototypes);
+
         PrototypeResponseDto responseDto = new PrototypeResponseDto(id, prototypesDto);
         return ResponseEntity.ok(responseDto);
     }
@@ -38,7 +52,15 @@ public class SlideController {
     @PostMapping("/prez/slides/{presentationId}")
     @Operation(summary = "슬라이드 생성")
     public ResponseEntity<SlidesDto> createSlides(@RequestBody PrototypesDto prototypesDto, @PathVariable("presentationId") Long id) {
-        SlidesDto slidesDto = prezService.makeSlide(prototypesDto, id);
+        OutlinesDto outlinesDto = new OutlinesDto();
+        List<OutlineDto> outlines = new ArrayList<>();
+
+        for (PrototypeDto prototype : prototypesDto.getSlides()) {
+            outlines.add(new OutlineDto(prototype.getSlideNumber(), prototype.getTitle(), prototype.getDescription()));
+        }
+        outlinesDto.setOutlines(outlines);
+
+        SlidesDto slidesDto = prezService.makeSlide(outlinesDto, id);
         return ResponseEntity.ok(slidesDto);
     }
 

--- a/src/main/java/prezwiz/server/controller/SlideControllerV2.java
+++ b/src/main/java/prezwiz/server/controller/SlideControllerV2.java
@@ -58,7 +58,7 @@ public class SlideControllerV2 {
     @PutMapping("/slides/{presentationId}")
     @Operation(summary = "슬라이드 수정")
     @ApiErrorCodeExample({ErrorCode.PRESENTATION_NOT_FOUND, ErrorCode.MEMBER_NOT_FOUND, ErrorCode.AUTH_INVALID_ACCESS_TOKEN})
-    public void updateSlideDataV2(@RequestBody SlidesDto slidesDto, @PathVariable("presentationId") Long id) {
+    public void updateSlideData(@RequestBody SlidesDto slidesDto, @PathVariable("presentationId") Long id) {
         prezServiceAdapter.updateSlide(id, slidesDto);
     }
 
@@ -76,10 +76,17 @@ public class SlideControllerV2 {
     }
 
     @GetMapping("/store")
-    @Operation(summary = "모든 슬라이드 정보 가져오기")
+    @Operation(summary = "모든 프레젠테이션 정보 가져오기")
     @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND})
     public ResponseEntity<PresentationsResponseDto> getPresentation() {
         PresentationsResponseDto presentations = prezServiceAdapter.getSlides();
         return ResponseEntity.ok(presentations);
+    }
+
+    @DeleteMapping("/store/{presentationId}")
+    @Operation(summary = "프레젠테이션 지우기")
+    @ApiErrorCodeExample({ErrorCode.MEMBER_NOT_FOUND, ErrorCode.AUTH_INVALID_ACCESS_TOKEN, ErrorCode.PRESENTATION_NOT_FOUND})
+    public void deletePresentation(@PathVariable("presentationId") Long id) {
+        prezServiceAdapter.deletePrez(id);
     }
 }

--- a/src/main/java/prezwiz/server/dto/response/OutlineResponseDto.java
+++ b/src/main/java/prezwiz/server/dto/response/OutlineResponseDto.java
@@ -1,12 +1,16 @@
 package prezwiz.server.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import prezwiz.server.dto.slide.outline.OutlineDto;
 
 import java.util.List;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class OutlineResponseDto {
 
     @JsonProperty("id")

--- a/src/main/java/prezwiz/server/entity/Contact.java
+++ b/src/main/java/prezwiz/server/entity/Contact.java
@@ -26,7 +26,7 @@ public class Contact {
     @Column
     private String message;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     Member member;
 

--- a/src/main/java/prezwiz/server/entity/Member.java
+++ b/src/main/java/prezwiz/server/entity/Member.java
@@ -47,7 +47,10 @@ public class Member {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "member")
+    // 영속성 전이를 위한 cascade = All,
+    // 고아객체 삭제를 위한 orphanRemoval = true
+    @OneToMany(mappedBy = "member",
+            cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Presentation> presentations = new ArrayList<>();
 
     // 발표자료 추가 메서드

--- a/src/main/java/prezwiz/server/entity/Presentation.java
+++ b/src/main/java/prezwiz/server/entity/Presentation.java
@@ -27,11 +27,11 @@ public class Presentation {
     @Column
     private String topic;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "SCRIPT_ID")
     private Script script;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "SLIDES_ID")
     private Slides slides;
 

--- a/src/main/java/prezwiz/server/entity/Slides.java
+++ b/src/main/java/prezwiz/server/entity/Slides.java
@@ -15,7 +15,8 @@ public class Slides {
     @Column(name = "SLIDES_ID")
     private Long id;
 
-    @OneToMany(mappedBy = "slides")
+    @OneToMany(mappedBy = "slides",
+            cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Slide> slideList = new ArrayList<>();
 
     public void addSlide(Slide slide) {

--- a/src/main/java/prezwiz/server/service/prez/PrezService.java
+++ b/src/main/java/prezwiz/server/service/prez/PrezService.java
@@ -3,6 +3,7 @@ package prezwiz.server.service.prez;
 import prezwiz.server.dto.response.PresentationsResponseDto;
 import prezwiz.server.dto.response.PrototypeResponseDto;
 import prezwiz.server.dto.slide.SlidesDto;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
 import prezwiz.server.dto.slide.prototype.PrototypesDto;
 
 public interface PrezService {
@@ -10,8 +11,8 @@ public interface PrezService {
     Long makeTable();
 
     // Create
-    PrototypesDto makeOutline(String topic, Long presentationId);
-    SlidesDto makeSlide(PrototypesDto prototypesDto, Long presentationId);
+    OutlinesDto makeOutline(String topic, Long presentationId);
+    SlidesDto makeSlide(OutlinesDto prototypesDto, Long presentationId);
     String makeScript(SlidesDto slidesDto, Long presentationId);
 
     // Read

--- a/src/main/java/prezwiz/server/service/prez/PrezService.java
+++ b/src/main/java/prezwiz/server/service/prez/PrezService.java
@@ -1,10 +1,8 @@
 package prezwiz.server.service.prez;
 
 import prezwiz.server.dto.response.PresentationsResponseDto;
-import prezwiz.server.dto.response.PrototypeResponseDto;
 import prezwiz.server.dto.slide.SlidesDto;
 import prezwiz.server.dto.slide.outline.OutlinesDto;
-import prezwiz.server.dto.slide.prototype.PrototypesDto;
 
 public interface PrezService {
 

--- a/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
+++ b/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
@@ -10,17 +10,15 @@ import prezwiz.server.common.exception.ErrorCode;
 import prezwiz.server.common.util.GptUtil;
 import prezwiz.server.dto.response.PresentationResponseDto;
 import prezwiz.server.dto.response.PresentationsResponseDto;
-import prezwiz.server.dto.response.PrototypeResponseDto;
 import prezwiz.server.dto.slide.SlideDto;
 import prezwiz.server.dto.slide.SlidesDto;
-import prezwiz.server.dto.slide.prototype.PrototypesDto;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
 import prezwiz.server.entity.*;
 import prezwiz.server.repository.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -44,8 +42,8 @@ public class PrezServiceImpl implements PrezService {
 
     @Override
     @Transactional
-    public PrototypesDto makeOutline(String topic, Long presentationId) {
-        PrototypesDto prototypes = gptUtil.getPrototypes(topic);
+    public OutlinesDto makeOutline(String topic, Long presentationId) {
+        OutlinesDto outlines = gptUtil.getOutlines(topic);
 
         Optional<Presentation> presentationOptional = presentationRepository.findById(presentationId);
         Presentation presentation = presentationOptional.orElseThrow(() -> new BizBaseException(ErrorCode.PRESENTATION_NOT_FOUND));
@@ -54,14 +52,14 @@ public class PrezServiceImpl implements PrezService {
         presentation.setMember(getCurrentUser());
         presentationRepository.save(presentation);
 
-        return prototypes;
+        return outlines;
     }
 
     @Override
     @Transactional
-    public SlidesDto makeSlide(PrototypesDto prototypesDto, Long presentationId) {
+    public SlidesDto makeSlide(OutlinesDto outlinesDto, Long presentationId) {
         Presentation presentation = getMyPresentation(presentationId);
-        SlidesDto slidesDto = gptUtil.getSlides(prototypesDto);
+        SlidesDto slidesDto = gptUtil.getSlides(outlinesDto);
 
         // 영속성 전이를 사용하지 않고 저장했음
         Slides slides = new Slides();

--- a/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
+++ b/src/main/java/prezwiz/server/service/prez/PrezServiceImpl.java
@@ -135,7 +135,8 @@ public class PrezServiceImpl implements PrezService {
     @Override
     @Transactional
     public void deletePrez(Long presentationId) {
-        presentationRepository.deleteById(presentationId);
+        Presentation presentation = getMyPresentation(presentationId);
+        presentationRepository.delete(presentation);
     }
 
     /**
@@ -146,7 +147,7 @@ public class PrezServiceImpl implements PrezService {
 
         Presentation presentation = presentationOptional.orElseThrow(() -> new BizBaseException(ErrorCode.PRESENTATION_NOT_FOUND));
         Member currentUser = getCurrentUser();
-        if (presentation.getMember().getId() != currentUser.getId()) {
+        if (!presentation.getMember().getId().equals(currentUser.getId())) {
             throw new BizBaseException(ErrorCode.AUTH_INVALID_ACCESS_TOKEN);
         }
         return presentation;

--- a/src/test/java/prezwiz/server/common/util/GptUtilImplTest.java
+++ b/src/test/java/prezwiz/server/common/util/GptUtilImplTest.java
@@ -1,7 +1,6 @@
 package prezwiz.server.common.util;
 
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,9 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.StopWatch;
 import prezwiz.server.dto.slide.SlidesDto;
+import prezwiz.server.dto.slide.outline.OutlinesDto;
 import prezwiz.server.dto.slide.prototype.PrototypesDto;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Slf4j
@@ -31,12 +29,12 @@ class GptUtilImplTest {
     void test() {
 
         stopWatch.start("prototype");
-        PrototypesDto prototypes = gptUtil.getPrototypes("객체지향");
-        log.info("prototypes: {}", prototypes);
+        OutlinesDto outlinesDto = gptUtil.getOutlines("객체지향");
+        log.info("prototypes: {}", outlinesDto);
         stopWatch.stop();
 
         stopWatch.start("slides");
-        SlidesDto slides = gptUtil.getSlides(prototypes);
+        SlidesDto slides = gptUtil.getSlides(outlinesDto);
         log.info("slides: {}", slides);
         stopWatch.stop();
 


### PR DESCRIPTION
1. prezService에서 더이상 사용하지 않는 prototypeDto에 대한 의존성을 제거했습니다.
2. entity를 영속성 전이를 사용해 저장하고 수정합니다.
3. 본인의 발표자료를 저장하고 삭제할수 있는 /api/store/{presentationId}로 delete 매핑되어있는 api를 생성했습니다.